### PR TITLE
Update MatRotation.js

### DIFF
--- a/src/dev/math/MatRotation.js
+++ b/src/dev/math/MatRotation.js
@@ -13,7 +13,7 @@ OIMO.EulerToAxis = function( ox, oy, oz ){// angles in radians
     var z =c1*s2*c3 - s1*c2*s3;
     var angle = 2 * Math.acos(w);
     var norm = x*x+y*y+z*z;
-    if (norm < 0.001) {
+    if (norm === 0) {
         x=1;
         y=z=0;
     } else {


### PR DESCRIPTION
This is causing some strange results when rotating by low or high or negative numbers on the X Y or Z axis, for example in the Codepen below I have rotated two platforms on the Y axis by 359 and 1 degree so the Red balls should fall and come to a rest on the Blue platforms, instead they roll off in opposite directions.

http://codepen.io/pigloo/pen/ZWaBrR/

This piece of code appears to have been ported from here: http://www.euclideanspace.com/maths/geometry/rotations/conversions/eulerToAngle/ but I think there is an error. 

I am not sure if this effects anything else but from my testing it solves the issue.
