### PR TITLE
Fix setRotation

### DIFF
--- a/src/core/RigidBody.js
+++ b/src/core/RigidBody.js
@@ -447,7 +447,7 @@ Object.assign( RigidBody.prototype, {
 
     setRotation: function ( rot ) {
 
-        this.newOrientation = new Quat().setFromEuler( rot.x * _Math.degtorad, rot.y * _Math.degtorad, rot.y * _Math.degtorad );//this.rotationVectToQuad( rot );
+        this.newOrientation = new Quat().setFromEuler( rot.x * _Math.degtorad, rot.y * _Math.degtorad, rot.z * _Math.degtorad );//this.rotationVectToQuad( rot );
         this.controlRot = true;
 
     },

--- a/src/core/RigidBody_X.js
+++ b/src/core/RigidBody_X.js
@@ -490,7 +490,7 @@ Object.assign( RigidBody.prototype, {
 
     setRotation: function ( rot ) {
 
-        this.newOrientation = new Quat().setFromEuler( rot.x * _Math.degtorad, rot.y * _Math.degtorad, rot.y * _Math.degtorad );//this.rotationVectToQuad( rot );
+        this.newOrientation = new Quat().setFromEuler( rot.x * _Math.degtorad, rot.y * _Math.degtorad, rot.z * _Math.degtorad );//this.rotationVectToQuad( rot );
         this.controlRot = true;
 
     },


### PR DESCRIPTION
Currently, `setRotation` is incorrectly setting the `z` value to the input's `y` value.