### PR TITLE
Removing duplicate multiplyScalar

### DIFF
--- a/src/math/Vec3.js
+++ b/src/math/Vec3.js
@@ -106,15 +106,6 @@ Object.assign( Vec3.prototype, {
 
     },
 
-    multiplyScalar: function( s ){
-
-        this.x *= s;
-        this.y *= s;
-        this.z *= s;
-        return this;
-
-    },
-
     /*scaleV: function( v ){
 
         this.x *= v.x;


### PR DESCRIPTION
When executed in strict mode in older browsers this code will fail due to multiple definitions.
`multiplayScalar` is defined later in code again.